### PR TITLE
Fixed ModuleNotFoundError and TypeError errors

### DIFF
--- a/domained.py
+++ b/domained.py
@@ -15,7 +15,7 @@
 # # Github - https://github.com/cakinney (Caleb Kinney)
 
 import argparse, os, requests, time, csv, datetime, glob, subprocess
-import ConfigParser, smtplib
+import configparser, smtplib
 from signal import signal, alarm, SIGALRM
 
 today = datetime.date.today()
@@ -189,7 +189,7 @@ def upgradeFiles():
         os.makedirs(binpath)
     print('Changing into domained home: {}'.format(script_path))
     os.chdir(script_path)
-    unameChk = subprocess.check_output(['uname', '-am'])
+    unameChk = str(subprocess.check_output(['uname', '-am']))
     if "kali" not in unameChk:
         print("\n\033[1;31mKali Linux Recommended!\033[1;37m")
         time.sleep(1)


### PR DESCRIPTION
I found 2 errors using Python 3.6.6 on Kali.

~~~
Traceback (most recent call last):
  File "domained.py", line 18, in <module>
    import ConfigParser, smtplib
ModuleNotFoundError: No module named 'ConfigParser'
~~~

Seems ConfigParser has to be imported lowercase now.

~~~
Traceback (most recent call last):
  File "domained.py", line 475, in <module>
    upgradeFiles()
  File "domained.py", line 193, in upgradeFiles
    if "kali" not in unameChk:
TypeError: a bytes-like object is required, not 'str'
~~~

Output of a subprocess is a bytes, so I forced to be a string.